### PR TITLE
Fix setBasicGear to execute where unit is local

### DIFF
--- a/functions/fn_setBasicLoadout.sqf
+++ b/functions/fn_setBasicLoadout.sqf
@@ -15,29 +15,27 @@
 
 params ["_unit"];
 
+if (!local _unit) exitWith {};
+
 private _randomUniform = selectRandom ["tacs_Uniform_Polo_TP_LS_TP_TB", "tacs_Uniform_Polo_TP_GS_TP_TB", "tacs_Uniform_Polo_TP_BS_LP_BB"];
 private _randomHeadgear = selectRandom ["tacs_Cap_BlackLogo", "tacs_Cap_TanLogo"];
 
-if (isServer) then {
-    //removal of items
-    removeAllWeapons _unit;
-    removeAllAssignedItems _unit;
-    removeUniform _unit;
-    removeVest _unit;
-    removeBackpack _unit;
-    removeHeadgear _unit;
-    removeGoggles _unit;
+// Remove gear
+removeAllWeapons _unit;
+removeAllAssignedItems _unit;
+removeUniform _unit;
+removeVest _unit;
+removeBackpack _unit;
+removeHeadgear _unit;
+removeGoggles _unit;
 
-    //adding basic gear
-    _unit forceAddUniform _randomUniform;
-    _unit addHeadgear _randomHeadgear;
-    _unit addItem "ItemMap";
-    _unit addItem "ItemCompass";
-    _unit addItem "ItemWatch";
-    _unit addItem "ACRE_PRC343";
-
-    //assigns items to player
-    _unit assignItem "ItemMap";
-    _unit assignItem "ItemCompass";
-    _unit assignItem "ItemWatch";
-};
+// Add basic gear
+_unit forceAddUniform _randomUniform;
+_unit addHeadgear _randomHeadgear;
+_unit addItem "ItemMap";
+_unit assignItem "ItemMap";
+_unit addItem "ItemCompass";
+_unit assignItem "ItemCompass";
+_unit addItem "ItemWatch";
+_unit assignItem "ItemWatch";
+_unit addItem "ACRE_PRC343";


### PR DESCRIPTION
Fixes #1 

`remove*` commands can take only local arguments - must be executed where unit is local.

Also reorganized the code a bit, no point running `selectRandom` on every machine if it's only used on one.
