### PR TITLE
Change default to LF line endings - Linux support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.png binary
+*.jpg binary
+*.paa binary


### PR DESCRIPTION
**When merged this pull request will:**
- Change default line endings to LF (from CRLF) for better Linux support
- Set PAA files as binary files (to prevent Git from trying to change the line ending)

CRLF is a Windows style line ending, LF is a Unix style line ending. msysGit (the most popular Git for Windows client - which you are also using @SyMP2005 ) does this by default, it converts to LF when you push, hence no files are changed here as this PR simply changes that default for anyone who doesn't have that default set.

After this is merged (and if it's merged) Git might complain when you edit any file, that is because your local repo will still have it with CRLF line ending, but usually Git figures that out when you try to commit it, it will simply register it correctly. However, you can also do the following in bash to convert all your local files to LF endings (only if your Git complains, generally it should work completely fine like it did until now):

```
git ls-files -z | xargs -0 rm
git checkout .
```

Also, any normal text editor can handle both CRLF and LF, however mixed up CRLF and LF can cause major issues all-around (mainly diffing code), using only CRLF just kills Unix environments, and Git for Windows can handle it on the fly, as well as any text editor (Atom even has a big text-button in bottom left corner).
