### PR TITLE
Fix AI wandering off from medical course

### DIFF
--- a/functions/fn_prepareMedicalExercise.sqf
+++ b/functions/fn_prepareMedicalExercise.sqf
@@ -29,6 +29,10 @@ private _info = [
 
 _controller setVariable [QGVAR(MedicalExerciseInfo), _info, true];
 
+{
+    _x enableSimulationGlobal false;
+} forEach _victims;
+
 // Add EH for AI movement
 [QGVAR(move), {
     params ["_victim", "_runWaypoint"];

--- a/functions/fn_resetMedicalExercise.sqf
+++ b/functions/fn_resetMedicalExercise.sqf
@@ -29,6 +29,7 @@ _objects params ["_victims", "_mine"];
 _victims = [];
 {
     private _victim = (createGroup resistance) createUnit [_x, ASLToAGL (_victimsStartPos select _forEachIndex), [], 0, "NONE"];
+    _victim enableSimulationGlobal false;
     _victims pushBack _victim;
 } forEach _victimsClass;
 

--- a/functions/fn_startMedicalExercise.sqf
+++ b/functions/fn_startMedicalExercise.sqf
@@ -26,6 +26,8 @@ TRACE_1("Start",_info);
 
 // Move victims to position
 {
+    _x enableSimulationGlobal true;
+
     // 'move' has local arguments
     [QGVAR(move), _x, [_x, _runWaypoint]] call ace_common_fnc_objectEvent;
 } forEach _victims;
@@ -59,15 +61,13 @@ if (isNull _mine) then {
     } forEach _victims;
 
     // Apply damage to specific victims
-      //victim 1 (select 0)
-        [_victims select 0] call ace_medical_fnc_setCardiacArrest;
-        [_victims select 0, 0.6, "leg_l", "grenade"] call ace_medical_fnc_addDamageToUnit;
-        [_victims select 0, 0.3, "leg_r", "stab"] call ace_medical_fnc_addDamageToUnit;
-        [_victims select 0, 0.3, "hand_l", "bullet"] call ace_medical_fnc_addDamageToUnit;
+    [_victims select 0] call ace_medical_fnc_setCardiacArrest;
+    [_victims select 0, 0.6, "leg_l", "grenade"] call ace_medical_fnc_addDamageToUnit;
+    [_victims select 0, 0.3, "leg_r", "stab"] call ace_medical_fnc_addDamageToUnit;
+    [_victims select 0, 0.3, "hand_l", "bullet"] call ace_medical_fnc_addDamageToUnit;
 
-      //victim 2 (select 1)
-        [_victims select 1, true, 10, true] call ace_medical_fnc_setUnconscious;
-        [_victims select 1, 0.5, "hand_r", "stab"] call ace_medical_fnc_addDamageToUnit;
-        [_victims select 1, 0.6, "leg_r", "explosive"] call ace_medical_fnc_addDamageToUnit;
+    [_victims select 1, true, 10, true] call ace_medical_fnc_setUnconscious;
+    [_victims select 1, 0.5, "hand_r", "stab"] call ace_medical_fnc_addDamageToUnit;
+    [_victims select 1, 0.6, "leg_r", "explosive"] call ace_medical_fnc_addDamageToUnit;
 
 }, [_victims, _runWaypoint, _controller]] call ace_common_fnc_waitUntilAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Title - ref. https://github.com/Theseus-Aegis/Olympus/issues/8#issuecomment-224194481

As for AI not having advanced medical, I'd say just enable advanced medical for all AI on Olympus, there isn't any AI fighting anyways and the few AI that are on Olympus won't cause any issues.

Create `ACE_Settings.hpp` and add:

```
class ACE_Settings {
    class ace_medical_enableFor {
        value = 1;
        typeName = "SCALAR";
    };
};
```

Then in `description.ext` at the end add:

```
#include "ACE_Settings.hpp"
```
