### PR TITLE
Fix damage oddities on Medical Exercise

### DIFF
--- a/functions/fn_prepareMedicalExercise.sqf
+++ b/functions/fn_prepareMedicalExercise.sqf
@@ -39,6 +39,11 @@ _controller setVariable [QGVAR(MedicalExerciseInfo), _info, true];
     (group _victim) move (getPos _runWaypoint);
 }] call CBA_fnc_addEventHandler;
 
+// Add EH for damage (requires local)
+[QGVAR(addDamageToUnit), ace_medical_fnc_addDamageToUnit] call CBA_fnc_addEventHandler;
+[QGVAR(adjustPainLevel), ace_medical_fnc_adjustPainLevel] call CBA_fnc_addEventHandler;
+[QGVAR(setCardiacArrest), ace_medical_fnc_setCardiacArrest] call CBA_fnc_addEventHandler;
+
 // Start action
 private _actionStart = [
     QGVAR(MedicalExerciseStart),

--- a/functions/fn_resetMedicalExercise.sqf
+++ b/functions/fn_resetMedicalExercise.sqf
@@ -19,7 +19,6 @@ private _info = _controller getVariable QGVAR(MedicalExerciseInfo);
 _info params ["_objects", "_victimsClass", "_victimsStartPos", "_mineClass", "_mineStartPos"];
 _objects params ["_victims", "_mine"];
 
-
 // Delete used victims
 {
     deleteVehicle _x;

--- a/functions/fn_startMedicalExercise.sqf
+++ b/functions/fn_startMedicalExercise.sqf
@@ -57,8 +57,8 @@ if (isNull _mine) then {
     // Apply damage to all victims
     // 'addDamageToUnit', 'setCardiacArrest' and 'adjustPainLevel' have to be called local to the unit
     {
-        [QGVAR(addDamageToUnit), [_x, 0.8, "body", "explosive"], _x] call CBA_fnc_targetEvent;
-        [QGVAR(adjustPainLevel), [_x, 0.6], _x] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_x, 0.1, "body", "explosive"], _x] call CBA_fnc_targetEvent;
+        [QGVAR(adjustPainLevel), [_x, 0.2], _x] call CBA_fnc_targetEvent;
     } forEach _victims;
 
     // Apply damage to specific victims
@@ -69,22 +69,22 @@ if (isNull _mine) then {
     // Victim 1
     [QGVAR(setCardiacArrest), [_victim1], _victim1] call CBA_fnc_targetEvent;
     [{
-        [QGVAR(addDamageToUnit), [_this, 0.6, "leg_l", "grenade"], _this] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_this, 0.1, "leg_l", "grenade"], _this] call CBA_fnc_targetEvent;
     }, _victim1, 1] call CBA_fnc_waitAndExecute;
     [{
-        [QGVAR(addDamageToUnit), [_this, 0.3, "leg_r", "stab"], _this] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_this, 0.2, "leg_r", "stab"], _this] call CBA_fnc_targetEvent;
     }, _victim1, 2] call CBA_fnc_waitAndExecute;
     [{
-        [QGVAR(addDamageToUnit), [_this, 0.3, "hand_l", "bullet"], _this] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_this, 0.1, "hand_l", "bullet"], _this] call CBA_fnc_targetEvent;
     }, _victim1, 3] call CBA_fnc_waitAndExecute;
 
     // Victim 2
     [_victim2, true, 10, true] call ace_medical_fnc_setUnconscious; // Handles locality
     [{
-        [QGVAR(addDamageToUnit), [_this, 0.5, "hand_r", "stab"], _this] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_this, 0.2, "hand_r", "stab"], _this] call CBA_fnc_targetEvent;
     }, _victim2, 1] call CBA_fnc_waitAndExecute;
     [{
-        [QGVAR(addDamageToUnit), [_this, 0.6, "leg_r", "explosive"], _this] call CBA_fnc_targetEvent;
+        [QGVAR(addDamageToUnit), [_this, 0.3, "leg_r", "explosive"], _this] call CBA_fnc_targetEvent;
     }, _victim2, 2] call CBA_fnc_waitAndExecute;
 }, [_victims, _controller, _runWaypoint], 30, {
     params ["", "_controller"];

--- a/functions/fn_startMedicalExercise.sqf
+++ b/functions/fn_startMedicalExercise.sqf
@@ -41,7 +41,7 @@ if (isNull _mine) then {
 
 // Wait for units to get to waypoint and set damage on them
 [{
-    params ["_victims", "_runWaypoint", "_controller"];
+    params ["_victims", "_controller", "_runWaypoint"];
 
     private _nearWaypointObjects = nearestObjects [ASLToAGL (getPosASL _runWaypoint), ["CAManBase"], 2];
     _nearWaypointObjects = _nearWaypointObjects select [0, 2];
@@ -49,7 +49,7 @@ if (isNull _mine) then {
     _controller getVariable [QGVAR(MedicalExerciseStarted), false] &&
     {([_victims select 0, _victims select 1] isEqualTo _nearWaypointObjects) || ([_victims select 1, _victims select 0] isEqualTo _nearWaypointObjects)}
 }, {
-    params ["_victims", "", "_controller"];
+    params ["_victims", "_controller"];
 
     // Exit if reset
     if !(_controller getVariable [QGVAR(MedicalExerciseStarted), false]) exitWith {};
@@ -86,4 +86,7 @@ if (isNull _mine) then {
     [{
         [QGVAR(addDamageToUnit), [_this, 0.6, "leg_r", "explosive"], _this] call CBA_fnc_targetEvent;
     }, _victim2, 2] call CBA_fnc_waitAndExecute;
-}, [_victims, _runWaypoint, _controller]] call ace_common_fnc_waitUntilAndExecute;
+}, [_victims, _controller, _runWaypoint], 30, {
+    params ["", "_controller"];
+    _controller call FUNC(resetMedicalExercise);
+}] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Call damage functions in correct locality (local to units) where required
- Add delay between `addDamageToUnit` calls (explanation in comments)

This should provide a lot more consistent results, but damage levels might have to be adjusted due to all damage being properly registered.